### PR TITLE
Fix invalid reference to HEAD

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
 	let diffCommand = vscode.commands.registerCommand('gitdiffandmergetool.diff', (param: any) => {
 		executeOperation(
 			param,
-			(targetFile: string) => { return ['difftool', '-y', 'head', targetFile] },
+			(targetFile: string) => { return ['difftool', '-y', 'HEAD', targetFile] },
 			(targetFile: string) => { return 'Launching diff tool for ' + targetFile });
 	});
 


### PR DESCRIPTION
On Windows, "head" and "HEAD" are both symbolic references to the head of the current branch, but on other platforms, only "HEAD" is meaningful. As a result, the `gitdiffandmergetool.diff` command throws the following error:

> fatal: ambiguous argument 'head': unknown revision or path not in the working tree.
> Use '--' to separate paths from revisions, like this:
> 'git <command> [<revision>...] -- [<file>...]'